### PR TITLE
Fix Dependencies, info via Dries007

### DIFF
--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -11,6 +11,8 @@
   "credits": "",
   "logoFile": "",
   "screenshots": [],
-  "dependencies": []
+  "requiredMods": [ "terrafirmacraft"],
+  "dependencies": ["terrafirmacraft"],
+  "dependants": []
 }
 ]

--- a/src/com/aleksey/merchants/MerchantsMod.java
+++ b/src/com/aleksey/merchants/MerchantsMod.java
@@ -25,7 +25,7 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid="MerchantsTFC", name="Merchants", version="1.1.2", dependencies="after:TerraFirmaCraft")
+@Mod(modid="MerchantsTFC", name="Merchants", version="1.1.2")
 public class MerchantsMod
 {
     @Instance("MerchantsTFC")


### PR DESCRIPTION
This PR should solve the crash:
`java.lang.NullPointerException: 

```
at com.bioxx.tfc.Core.TFC_Core.getSuperSeed(TFC_Core.java:1414)
at com.bioxx.tfc.api.Crafting.AnvilRecipe.<init>(AnvilRecipe.java:30)
at com.aleksey.decorations.Core.Recipes.registerAnvilRecipes(Recipes.java:151)
at com.aleksey.decorations.Handlers.ChunkEventHandler.onLoadWorld(ChunkEventHandler.java:16)
at cpw.mods.fml.common.eventhandler.ASMEventHandler_0_ChunkEventHandler_onLoadWorld_Load.invoke(.dynamic:-1)
at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:138)
at net.minecraft.server.MinecraftServer.func_71247_a(MinecraftServer.java:230)
at net.minecraft.server.dedicated.DedicatedServer.func_71197_b(DedicatedServer.java:258)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:387)
at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)`
```

This is due to Decorations loading before TFC.

via Dries

You either have to specify @Mod.useMetadata = false and use @Mod.dependencies = ...
OR
Specify all dependencies in the mcmod.info file.
